### PR TITLE
automatically set domain and secure flag

### DIFF
--- a/src/PhpSession.php
+++ b/src/PhpSession.php
@@ -143,11 +143,7 @@ class PhpSession implements MiddlewareInterface
             session_id($id);
         }
 
-        $options = $this->options;
-        if ($this->isRememberMe($request)) {
-            $options["cookie_lifetime"] = $this->rememberMeLifetime;
-        }
-        session_start($options);
+        session_start($this->options);
 
         // Session ID regeneration
         self::runIdRegeneration($this->regenerateIdInterval, $this->sessionIdExpiryKey);


### PR DESCRIPTION
set domain and secure flag by default based on request information
can be configured using the new auto() method
it's probably much better anyway to set these (secure true on https and domain if possible) whenever possible, so encouraging best practices seems like a good idea