### PR TITLE
fix: get session name from options if available and not explicity set

### DIFF
--- a/src/PhpSession.php
+++ b/src/PhpSession.php
@@ -91,7 +91,7 @@ class PhpSession implements MiddlewareInterface
         self::checkSessionCanStart();
 
         // Session name
-        $name = $this->name ?: session_name();
+        $name = $this->name ?? $this->options['name'] ?? session_name();
         session_name($name);
 
         // Session ID


### PR DESCRIPTION
I tried using ternary operators first, but 3 tests failed. So changed to null coalescing operators and all test pass.

Thanks